### PR TITLE
Modify scripts required to execute CRAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To train the model(s) in the paper, run this command:
 ```train
 cd experiments/
 bash train.sh config.yaml 4 0,1,2,3 1111
-# bash train.sh <config> <num gpus> <gpu ids> <master port>
+# bash train_torch.sh <config> <num gpus> <gpu ids> <master port>
 ```
 
 ## Evaluation
@@ -45,7 +45,7 @@ To evaluate a trained model, run:
 ```eval
 cd experiments/
 bash eval.sh config.yaml 4 0,1,2,3 1111
-# bash eval.sh <config> <num gpus> <gpu ids> <master port>
+# bash eval_torch.sh <config> <num gpus> <gpu ids> <master port>
 ```
 
 ## Results

--- a/experiments/download_mvtecad.sh
+++ b/experiments/download_mvtecad.sh
@@ -3,5 +3,5 @@ cd mvtec
 # Download MVTec anomaly detection dataset
 wget https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420938113-1629952094/mvtec_anomaly_detection.tar.xz
 tar -xf mvtec_anomaly_detection.tar.xz
-mv ../data/MVTec-AD/mvtec_anomaly_detection
+mv mvtec ../data/MVTec-AD/mvtec_anomaly_detection
 rm mvtec_anomaly_detection.tar.xz

--- a/experiments/download_mvtecad.sh
+++ b/experiments/download_mvtecad.sh
@@ -1,0 +1,7 @@
+mkdir mvtec
+cd mvtec
+# Download MVTec anomaly detection dataset
+wget https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420938113-1629952094/mvtec_anomaly_detection.tar.xz
+tar -xf mvtec_anomaly_detection.tar.xz
+mv ../data/MVTec-AD/mvtec_anomaly_detection
+rm mvtec_anomaly_detection.tar.xz

--- a/experiments/train_torch.sh
+++ b/experiments/train_torch.sh
@@ -1,2 +1,2 @@
 export PYTHONPATH=../:$PYTHONPATH
-CUDA_VISIBLE_DEVICES=$3 python -m torch.distributed.launch --master_port $4 --nproc_per_node=$2 ../tools/train_val.py --config $1
+CUDA_VISIBLE_DEVICES=$3 python -m torch.distributed.launch --use_env --master_port $4 --nproc_per_node=$2 ../tools/train_val.py --config $1


### PR DESCRIPTION
1. download script of MVTec AD dataset is added. ('experiments/download_mvtecad.sh')
2. add '--use_env' option for 'experiments/train_torch.sh'. It helps to remove some execution errors.
3. correct example command of README.md 'bash train.sh...' to 'bash train_torch.sh...' and 'bash eval.sh...' to 'bash eval_torch.sh...'.

Please review and consider to merge this pull request.